### PR TITLE
Implemented Disconnection of device on NB API message

### DIFF
--- a/src/cgw_connection_server.rs
+++ b/src/cgw_connection_server.rs
@@ -272,6 +272,7 @@ enum CGWNBApiParsedMsgType {
     InfrastructureGroupDelete,
     InfrastructureGroupInfrasAdd(Vec<MacAddress>),
     InfrastructureGroupInfrasDel(Vec<MacAddress>),
+    InfrastructureGroupInfraDisconnect(MacAddress),
     InfrastructureGroupInfraMsg(MacAddress, String, Option<u64>),
     RebalanceGroups,
 }
@@ -692,6 +693,14 @@ impl CGWConnectionServer {
         }
 
         #[derive(Debug, Serialize, Deserialize)]
+        struct InfraGroupInfraDisconnect {
+            r#type: String,
+            infra_group_id: String,
+            infra_group_infras: MacAddress,
+            uuid: Uuid,
+        }
+
+        #[derive(Debug, Serialize, Deserialize)]
         struct RebalanceGroups {
             r#type: String,
             infra_group_id: String,
@@ -766,6 +775,16 @@ impl CGWConnectionServer {
                     ),
                 ));
             }
+            "infrastructure_group_infras_disconnect" => {
+                let json_msg: InfraGroupInfraDisconnect = serde_json::from_str(pload).ok()?;
+                return Some(CGWNBApiParsedMsg::new(
+                    json_msg.uuid,
+                    group_id,
+                    CGWNBApiParsedMsgType::InfrastructureGroupInfraDisconnect(
+                        json_msg.infra_group_infras,
+                    ),
+                ));
+            }
             "rebalance_groups" => {
                 let json_msg: RebalanceGroups = serde_json::from_str(pload).ok()?;
                 return Some(CGWNBApiParsedMsg::new(
@@ -818,6 +837,31 @@ impl CGWConnectionServer {
                 0i64
             }
         }
+    }
+
+    async fn disconnect_infrastructure_device(&self, device_mac: MacAddress) -> Result<()> {
+        let tx_opt = {
+            let connmap_lock = self.connmap.map.read().await;
+            connmap_lock.get(&device_mac).cloned()
+        };
+
+        let Some(tx) = tx_opt else {
+            return Err(Error::ConnectionServer("Device is not connected".to_string()));
+        };
+
+        if let Err(e) = tx.send(CGWConnectionProcessorReqMsg::AddNewConnectionShouldClose) {
+            warn!(
+                "Failed to send disconnection request for {}! Error: {e}",
+                device_mac.to_hex_string()
+            );
+        }
+
+        self.enqueue_mbox_message_to_cgw_server(CGWConnectionServerReqMsg::ConnectionClosed(
+            device_mac,
+        ))
+        .await;
+
+        Ok(())
     }
 
     async fn process_internal_nb_api_mbox(
@@ -1204,23 +1248,60 @@ impl CGWConnectionServer {
                 // forwarded to.
                 // In order to get it, match to <any> parsed msg, and
                 // get only gid field.
-                let gid: i32 = match parsed_msg {
-                    CGWNBApiParsedMsg { gid, .. } => gid,
+                let gid: i32 = match &parsed_msg {
+                    CGWNBApiParsedMsg { gid, .. } => *gid,
                 };
 
-                match self
-                    .cgw_remote_discovery
-                    .get_infra_group_owner_id(gid)
-                    .await
-                {
+                let dst_cgw_id = match &parsed_msg {
+                    CGWNBApiParsedMsg {
+                        gid: 0,
+                        msg_type:
+                            CGWNBApiParsedMsgType::InfrastructureGroupInfraDisconnect(device_mac),
+                        ..
+                    } => self
+                        .cgw_remote_discovery
+                        .get_device_connected_shard_id(device_mac)
+                        .await,
+                    _ => self.cgw_remote_discovery.get_infra_group_owner_id(gid).await,
+                };
+
+                match dst_cgw_id {
                     Some(dst_cgw_id) => {
                         if dst_cgw_id == self.local_cgw_id {
+                            if let CGWNBApiParsedMsg {
+                                uuid,
+                                msg_type:
+                                    CGWNBApiParsedMsgType::InfrastructureGroupInfraDisconnect(
+                                        device_mac,
+                                    ),
+                                ..
+                            } = &parsed_msg
+                            {
+                                info!(
+                                    "disconnect uuid {} for infra {} resolved to local shard {}",
+                                    uuid, device_mac, self.local_cgw_id
+                                );
+                            }
                             local_cgw_msg_buf.push(
                                 CGWConnectionNBAPIReqMsg::EnqueueNewMessageFromNBAPIListener(
                                     key, payload, origin,
                                 ),
                             );
                         } else {
+                            if let CGWNBApiParsedMsg {
+                                uuid,
+                                msg_type:
+                                    CGWNBApiParsedMsgType::InfrastructureGroupInfraDisconnect(
+                                        device_mac,
+                                    ),
+                                ..
+                            } = &parsed_msg
+                            {
+                                info!(
+                                    "relaying disconnect uuid {} for infra {} from shard {} to shard {}",
+                                    uuid, device_mac, self.local_cgw_id, dst_cgw_id
+                                );
+                            }
                             relayed_cgw_msg_buf.push((
                                 dst_cgw_id,
                                 CGWConnectionNBAPIReqMsg::EnqueueNewMessageFromNBAPIListener(
@@ -1230,6 +1311,20 @@ impl CGWConnectionServer {
                         }
                     }
                     None => {
+                        if let CGWNBApiParsedMsg {
+                            uuid,
+                            msg_type:
+                                CGWNBApiParsedMsgType::InfrastructureGroupInfraDisconnect(
+                                    device_mac,
+                                ),
+                            ..
+                        } = &parsed_msg
+                        {
+                            info!(
+                                "disconnect uuid {} for infra {} has no shard mapping, handling on local shard {}",
+                                uuid, device_mac, self.local_cgw_id
+                            );
+                        }
                         // Failed to find destination GID shard ID owner
                         // It is more likely GID does not exist
                         // Add request to local message buffer - let CGW process request
@@ -1595,6 +1690,78 @@ impl CGWConnectionServer {
 
                                         warn!("Failed to destroy few MACs from infras list (partial delete)!");
                                         continue;
+                                    }
+                                }
+                            }
+                        }
+                        CGWNBApiParsedMsg {
+                            uuid,
+                            gid,
+                            msg_type:
+                                CGWNBApiParsedMsgType::InfrastructureGroupInfraDisconnect(
+                                    device_mac,
+                                ),
+                        } => {
+                            let is_connected_locally = {
+                                let devices_cache = self.devices_cache.read().await;
+                                matches!(
+                                    devices_cache.get_device(&device_mac),
+                                    Some(infra)
+                                        if infra.get_device_state()
+                                            == CGWDeviceState::CGWDeviceConnected
+                                )
+                            };
+
+                            if !is_connected_locally {
+                                if let Ok(resp) = cgw_construct_infra_enqueue_response(
+                                    self.local_cgw_id,
+                                    uuid,
+                                    false,
+                                    Some(format!(
+                                        "Failed to disconnect infra {device_mac}, uuid {uuid}: device is not connected on shard {}",
+                                        self.local_cgw_id
+                                    )),
+                                    local_shard_partition_key.clone(),
+                                ) {
+                                    self.enqueue_mbox_message_from_cgw_to_nb_api(gid, resp);
+                                } else {
+                                    error!("Failed to construct device_enqueue message!");
+                                }
+
+                                continue;
+                            }
+
+                            match self.disconnect_infrastructure_device(device_mac).await {
+                                Ok(()) => {
+                                    info!(
+                                        "disconnect uuid {} accepted for infra {} on shard {} without group_id modification",
+                                        uuid, device_mac, self.local_cgw_id
+                                    );
+                                    if let Ok(resp) = cgw_construct_infra_enqueue_response(
+                                        self.local_cgw_id,
+                                        uuid,
+                                        true,
+                                        None,
+                                        local_shard_partition_key.clone(),
+                                    ) {
+                                        self.enqueue_mbox_message_from_cgw_to_nb_api(gid, resp);
+                                    } else {
+                                        error!("Failed to construct device_enqueue message!");
+                                    }
+                                }
+                                Err(e) => {
+                                    if let Ok(resp) = cgw_construct_infra_enqueue_response(
+                                        self.local_cgw_id,
+                                        uuid,
+                                        false,
+                                        Some(format!(
+                                            "Failed to disconnect infra {device_mac}, uuid {uuid}: {e}"
+                                        )),
+                                        local_shard_partition_key.clone(),
+                                    ) {
+                                        self.enqueue_mbox_message_from_cgw_to_nb_api(gid, resp);
+                                    } else {
+                                        error!("Failed to construct device_enqueue message!");
                                     }
                                 }
                             }

--- a/src/cgw_remote_discovery.rs
+++ b/src/cgw_remote_discovery.rs
@@ -211,6 +211,12 @@ async fn cgw_create_redis_client(redis_args: &CGWRedisArgs) -> Result<Client> {
 }
 
 impl CGWRemoteDiscovery {
+    fn parse_shard_id_from_device_cache_key(key: &str) -> Option<i32> {
+        let (shard_key, _) = key.split_once('|')?;
+        let shard_id = shard_key.strip_prefix(REDIS_KEY_SHARD_ID_PREFIX)?;
+        shard_id.parse().ok()
+    }
+
     pub async fn new(app_args: &AppArgs) -> Result<Self> {
         debug!(
             "Trying to create redis db connection ({}:{})",
@@ -1066,6 +1072,21 @@ impl CGWRemoteDiscovery {
                                 }
                             }
                         } else {
+                            match self
+                                .update_existing_device_entry_in_redis_cache(&device_mac, gid, true)
+                                .await
+                            {
+                                Ok(true) => {
+                                    assigned_infras_num += 1;
+                                    success_infras.push(device_mac);
+                                    continue;
+                                }
+                                Ok(false) => {}
+                                Err(e) => {
+                                    error!("{e}");
+                                }
+                            }
+
                             let device = CGWDevice::new(
                                 CGWDeviceType::default(),
                                 CGWDeviceState::CGWDeviceDisconnected,
@@ -1202,6 +1223,8 @@ impl CGWRemoteDiscovery {
         shard_id: i32,
         stream: Vec<(String, String)>,
     ) -> Result<()> {
+        let stream_len = stream.len();
+
         // try to use internal cache first
         if let Some(cl) = self.remote_cgws_map.read().await.get(&shard_id) {
             if let Err(e) = cl.client.relay_request_stream(stream).await {
@@ -1564,6 +1587,158 @@ impl CGWRemoteDiscovery {
             }
 
         self.db_accessor.get_infra_group_id_by_mac(*mac).await
+    }
+
+    /// Resolve the shard whose Redis db1 cache entry shows the device as connected.
+    pub async fn get_device_connected_shard_id(&self, device_mac: &MacAddress) -> Option<i32> {
+        let mut con = self.redis_infra_cache_client.clone();
+
+        let key = format!("shard_id_*|{}", device_mac);
+        let redis_keys: Vec<String> =
+            match redis::cmd("KEYS").arg(&key).query_async(&mut con).await {
+                Err(e) => {
+                    if e.is_io_error() {
+                        Self::set_redis_health_state_not_ready(e.to_string()).await;
+                    }
+                    error!(
+                        "Failed to get shard for device {} from Redis cache! Error: {}",
+                        device_mac.to_hex_string(),
+                        e
+                    );
+                    return None;
+                }
+                Ok(keys) => keys,
+            };
+
+        for redis_key in redis_keys {
+            let Some(shard_id) = Self::parse_shard_id_from_device_cache_key(&redis_key) else {
+                continue;
+            };
+
+            let device_str: String =
+                match redis::cmd("GET").arg(&redis_key).query_async(&mut con).await {
+                    Ok(dev) => dev,
+                    Err(e) => {
+                        if e.is_io_error() {
+                            Self::set_redis_health_state_not_ready(e.to_string()).await;
+                        }
+                        error!(
+                            "Failed to get device cache entry {}! Error: {}",
+                            redis_key, e
+                        );
+                        continue;
+                    }
+                };
+
+            match serde_json::from_str::<CGWDevice>(&device_str) {
+                Ok(dev) if dev.get_device_state() == CGWDeviceState::CGWDeviceConnected => {
+                    return Some(shard_id);
+                }
+                Ok(_) => continue,
+                Err(e) => {
+                    error!("Failed to deserialize device from Redis cache! Error: {e}");
+                    continue;
+                }
+            }
+        }
+
+        None
+    }
+
+    async fn update_existing_device_entry_in_redis_cache(
+        &self,
+        device_mac: &MacAddress,
+        group_id: i32,
+        remains_in_db: bool,
+    ) -> Result<bool> {
+        let mut con = self.redis_infra_cache_client.clone();
+        let pattern = format!("shard_id_*|{}", device_mac);
+        let redis_keys: Vec<String> = match redis::cmd("KEYS")
+            .arg(&pattern)
+            .query_async(&mut con)
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                if e.is_io_error() {
+                    Self::set_redis_health_state_not_ready(e.to_string()).await;
+                }
+                return Err(Error::RemoteDiscovery(
+                    "Failed to query Redis devices cache",
+                ));
+            }
+        };
+
+        let mut fallback: Option<(String, CGWDevice)> = None;
+
+        for redis_key in redis_keys {
+            let device_str: String = match redis::cmd("GET").arg(&redis_key).query_async(&mut con).await
+            {
+                Ok(dev) => dev,
+                Err(e) => {
+                    if e.is_io_error() {
+                        Self::set_redis_health_state_not_ready(e.to_string()).await;
+                    }
+                    continue;
+                }
+            };
+
+            let Ok(mut device) = serde_json::from_str::<CGWDevice>(&device_str) else {
+                continue;
+            };
+
+            device.set_device_group_id(group_id);
+            device.set_device_remains_in_db(remains_in_db);
+
+            if device.get_device_state() == CGWDeviceState::CGWDeviceConnected {
+                let device_json = serde_json::to_string(&device).map_err(|_| {
+                    Error::RemoteDiscovery("Failed to serialize device cache entry")
+                })?;
+                let res: RedisResult<()> = redis::cmd("SET")
+                    .arg(&redis_key)
+                    .arg(&device_json)
+                    .query_async(&mut con)
+                    .await;
+                match res {
+                    Ok(()) => return Ok(true),
+                    Err(e) => {
+                        if e.is_io_error() {
+                            Self::set_redis_health_state_not_ready(e.to_string()).await;
+                        }
+                        return Err(Error::RemoteDiscovery(
+                            "Failed to update Redis devices cache",
+                        ));
+                    }
+                }
+            }
+
+            if fallback.is_none() {
+                fallback = Some((redis_key, device));
+            }
+        }
+
+        if let Some((redis_key, device)) = fallback {
+            let device_json = serde_json::to_string(&device)
+                .map_err(|_| Error::RemoteDiscovery("Failed to serialize device cache entry"))?;
+            let res: RedisResult<()> = redis::cmd("SET")
+                .arg(&redis_key)
+                .arg(&device_json)
+                .query_async(&mut con)
+                .await;
+            match res {
+                Ok(()) => return Ok(true),
+                Err(e) => {
+                    if e.is_io_error() {
+                        Self::set_redis_health_state_not_ready(e.to_string()).await;
+                    }
+                    return Err(Error::RemoteDiscovery(
+                        "Failed to update Redis devices cache",
+                    ));
+                }
+            }
+        }
+
+        Ok(false)
     }
 
     pub async fn sync_devices_cache_with_redis(


### PR DESCRIPTION
**Overview**
 ---
This PR introduces support for disconnecting devices over WebSocket based on messages received from the NB API via the CnC Kafka topic.

**Background**
---

Previously, there was no mechanism to trigger a device disconnection through Kafka messages. This enhancement enables the system to react to NB-originated CnC messages and perform real-time WebSocket disconnections.

### **What’s Implemented**

* Parses incoming messages to identify target device (e.g., via MAC address)

* Triggers WebSocket disconnection for the corresponding device

* Ensures disconnection is executed only by the correct shard

* **Sharding Behavior**

  * Each shard consumes from the same Kafka topic (consumer group)
  * Based on partition assignment, a shard processes the message
  * If the device belongs to another shard:

    * Message is relayed/routed to the appropriate shard